### PR TITLE
Support parsing arbitrary large LTL formulas. Fixes a segfault and an incorrect iteration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+Src/spin
+Src/y.tab.h
+Src/y.output

--- a/Src/main.c
+++ b/Src/main.c
@@ -80,7 +80,7 @@ static char	**nvr_file = (char **) 0;
 static char	*ltl_claims = (char *) 0;
 static char	*pan_runtime = "";
 static char	*pan_comptime = "";
-static char	formula[4096];
+static char	*formula = NULL;
 static FILE	*fd_ltl = (FILE *) 0;
 static char	*PreArg[64];
 static int	PreCnt = 0;
@@ -1041,12 +1041,14 @@ samecase:			if (buzzed != 0)
 		{	printf("spin: cannot open %s\n", *ltl_file);
 			alldone(1);
 		}
-		if (!fgets(formula, 4096, tl_out))
+		size_t linebuffsize = 0;
+		ssize_t length = getline(&formula, &linebuffsize, tl_out);
+		if (!formula || !length)
 		{	printf("spin: cannot read %s\n", *ltl_file);
 		}
 		fclose(tl_out);
 		tl_out = stdout;
-		*ltl_file = (char *) formula;
+		*ltl_file = formula;
 	}
 	if (argc > 1)
 	{	FILE *fd = stdout;

--- a/Src/spin.h
+++ b/Src/spin.h
@@ -294,6 +294,7 @@ Symbol	*prep_inline(Symbol *, Lextok *);
 
 char	*put_inline(FILE *, char *);
 char	*emalloc(size_t);
+char	*erealloc(void*, size_t, size_t);
 long	Rand(void);
 
 int	any_oper(Lextok *, int);

--- a/Src/spin.y
+++ b/Src/spin.y
@@ -1057,8 +1057,8 @@ recursive(FILE *fd, Lextok *n)
 static Lextok *
 ltl_to_string(Lextok *n)
 {	Lextok *m = nn(ZN, 0, ZN, ZN);
-	char *retval;
-	char ltl_formula[2048];
+	ssize_t retval;
+	char *ltl_formula = NULL;
 	FILE *tf = fopen(TMP_FILE1, "w+"); /* tmpfile() fails on Windows 7 */
 
 	/* convert the parsed ltl to a string
@@ -1077,21 +1077,21 @@ ltl_to_string(Lextok *n)
 	dont_simplify = 0;
 	(void) fseek(tf, 0L, SEEK_SET);
 
-	memset(ltl_formula, 0, sizeof(ltl_formula));
-	retval = fgets(ltl_formula, sizeof(ltl_formula), tf);
+	size_t linebuffsize = 0;
+	retval = getline(&ltl_formula, &linebuffsize, tf);
 	fclose(tf);
 
 	(void) unlink(TMP_FILE1);
 
 	if (!retval)
-	{	printf("%p\n", retval);
+	{	printf("%ld\n", retval);
 		fatal("could not translate ltl ltl_formula", 0);
 	}
 
 	if (1) printf("ltl %s: %s\n", ltl_name, ltl_formula);
 
 	m->sym = lookup(ltl_formula);
-
+	free(ltl_formula);
 	return m;
 }
 

--- a/Src/tl.h
+++ b/Src/tl.h
@@ -94,6 +94,7 @@ int	isequal(Node *, Node *);
 int	tl_Getchar(void);
 
 void	*tl_emalloc(int);
+void	*tl_erealloc(void*, int, int);
 void	a_stats(void);
 void	addtrans(Graph *, char *, Node *, char *);
 void	cache_stats(void);

--- a/Src/tl_main.c
+++ b/Src/tl_main.c
@@ -23,7 +23,7 @@ int	state_cnt = 0;
 unsigned long	All_Mem = 0;
 char	*claim_name;
 
-static char	uform[4096];
+static char	*uform;
 static int	hasuform=0, cnt=0;
 
 extern void cache_stats(void);
@@ -115,7 +115,6 @@ tl_main(int argc, char *argv[])
 	tl_errs    = 0;
 	tl_terse   = 0;
 	All_Mem = 0;
-	memset(uform, 0, sizeof(uform));
 	hasuform=0;
 	cnt=0;
 	claim_name = (char *) 0;
@@ -136,8 +135,10 @@ tl_main(int argc, char *argv[])
 					||  argv[1][i] == '\n')
 						argv[1][i] = ' ';
 				}
+				size_t len = strlen(argv[1]);
+                uform = tl_emalloc(len + 1);
 				strcpy(uform, argv[1]);
-				hasuform = (int) strlen(uform);
+				hasuform = (int) len;
 				break;
 		case 'v':	tl_verbose++;
 				break;

--- a/Src/tl_mem.c
+++ b/Src/tl_mem.c
@@ -80,16 +80,16 @@ tl_emalloc(int U)
 }
 
 // FIXME: inefficient
-void* tl_erealloc(void *v, int U, int old_size)
-{
-    void* tmp = tl_emalloc(U);
+void*
+tl_erealloc(void *v, int U, int old_size)
+{	void* tmp = tl_emalloc(U);
 
-    if (v)
-    {   strncpy(tmp, v, old_size);
-        tfree(v);
-    }
+	if (v)
+	{	strncpy(tmp, v, old_size);
+		tfree(v);
+	}
 
-    return tmp;
+	return tmp;
 }
 
 void

--- a/Src/tl_mem.c
+++ b/Src/tl_mem.c
@@ -79,6 +79,19 @@ tl_emalloc(int U)
 	return rp;
 }
 
+// FIXME: inefficient
+void* tl_erealloc(void *v, int U, int old_size)
+{
+    void* tmp = tl_emalloc(U);
+
+    if (v)
+    {   strncpy(tmp, v, old_size);
+        tfree(v);
+    }
+
+    return tmp;
+}
+
 void
 tfree(void *v)
 {	union M *m = (union M *) v;

--- a/Src/tl_trans.c
+++ b/Src/tl_trans.c
@@ -447,13 +447,16 @@ catSlist(Symbol *a, Symbol *b)
 	/* remove duplicates from b */
 	for (p1 = a; p1; p1 = p1->next)
 	{	p3 = ZS;
-		for (p2 = b; p2; p2 = p2->next)
-		{	if (strcmp(p1->name, p2->name))
+		p2 = b;
+		while (p2)
+		{ if (strcmp(p1->name, p2->name))
 			{	p3 = p2;
+				p2 = p2->next;
 				continue;
 			}
 			tmp = p2->next;
 			tfree((void *) p2);
+			p2 = tmp;
 			if (p3)
 				p3->next = tmp;
 			else

--- a/Src/tl_trans.c
+++ b/Src/tl_trans.c
@@ -20,7 +20,10 @@ static Mapping	*Mapped = (Mapping *) 0;
 static Graph	*Nodes_Set = (Graph *) 0;
 static Graph	*Nodes_Stack = (Graph *) 0;
 
-static char	dumpbuf[4096];
+static char	*dumpbuf = NULL;
+static size_t dumpbuf_size = 0;
+static size_t dumpbuf_capacity = 0;
+
 static int	Red_cnt  = 0;
 static int	Lab_cnt  = 0;
 static int	Base     = 0;
@@ -49,6 +52,20 @@ static void	push_stack(Graph *);
 static void	sdump(Node *);
 
 void
+append_to_dumpbuf(char* s)
+{
+    size_t len = strlen(s);
+    size_t size_needed = dumpbuf_size + len + 1;
+    if (size_needed > dumpbuf_capacity) {
+        dumpbuf = tl_erealloc(dumpbuf, size_needed, dumpbuf_capacity);
+        dumpbuf_capacity = size_needed;
+    }
+
+    strncpy(&(dumpbuf[dumpbuf_size]), s, len + 1);
+    dumpbuf_size += len;
+}
+
+void
 ini_trans(void)
 {
 	Stack_mx = 0;
@@ -59,7 +76,10 @@ ini_trans(void)
 	Nodes_Set = (Graph *) 0;
 	Nodes_Stack = (Graph *) 0;
 
-	memset(dumpbuf, 0, sizeof(dumpbuf));
+	dumpbuf_capacity = 4096;
+	dumpbuf = tl_emalloc(dumpbuf_capacity);
+	dumpbuf_size = 0;
+	memset(dumpbuf, 0, dumpbuf_capacity);
 	Red_cnt  = 0;
 	Lab_cnt  = 0;
 	Base     = 0;
@@ -548,33 +568,33 @@ static void
 sdump(Node *n)
 {
 	switch (n->ntyp) {
-	case PREDICATE:	strcat(dumpbuf, n->sym->name);
+	case PREDICATE:	append_to_dumpbuf(n->sym->name);
 			break;
-	case U_OPER:	strcat(dumpbuf, "U");
+	case U_OPER:	append_to_dumpbuf("U");
 			goto common2;
-	case V_OPER:	strcat(dumpbuf, "V");
+	case V_OPER:	append_to_dumpbuf("V");
 			goto common2;
-	case OR:	strcat(dumpbuf, "|");
+	case OR:	append_to_dumpbuf("|");
 			goto common2;
-	case AND:	strcat(dumpbuf, "&");
+	case AND:	append_to_dumpbuf("&");
 common2:		sdump(n->rgt);
 common1:		sdump(n->lft);
 			break;
 #ifdef NXT
-	case NEXT:	strcat(dumpbuf, "X");
+	case NEXT:	append_to_dumpbuf("X");
 			goto common1;
 #endif
-	case CEXPR:	strcat(dumpbuf, "c_expr {");
+	case CEXPR:	append_to_dumpbuf("c_expr {");
 			sdump(n->lft);
-			strcat(dumpbuf, "}");
+			append_to_dumpbuf("}");
 			break;
-	case NOT:	strcat(dumpbuf, "!");
+	case NOT:	append_to_dumpbuf("!");
 			goto common1;
-	case TRUE:	strcat(dumpbuf, "T");
+	case TRUE:	append_to_dumpbuf("T");
 			break;
-	case FALSE:	strcat(dumpbuf, "F");
+	case FALSE:	append_to_dumpbuf("F");
 			break;
-	default:	strcat(dumpbuf, "?");
+	default:	append_to_dumpbuf("?");
 			break;
 	}
 }
@@ -587,9 +607,15 @@ DoDump(Node *n)
 	if (n->ntyp == PREDICATE)
 		return n->sym;
 
-	dumpbuf[0] = '\0';
-	sdump(n);
-	return tl_lookup(dumpbuf);
+    if (dumpbuf) {
+        dumpbuf[0] = '\0';
+        dumpbuf_size = 0;
+        sdump(n);
+        return tl_lookup(dumpbuf);
+    }
+
+    sdump(n);
+    return tl_lookup("");
 }
 
 static int


### PR DESCRIPTION
This pull request:
 - Gets rid of fixed-length arrays (max 2048 or 4096) related to parsing LTL formulas.
 - Fixes an incorrect iteration in tl_trans.c.

Trying to compile a Promela model containing a large LTL formula leads to a segmentation fault. Fixing the out of bound access causing this segmentation fault is the first step to fix this bug. Second step is to allow parsing large formulas everywhere else in the parsing logic, so formulas don't get truncated.

I am emulating realloc to do this. My implementation is not efficient and could be improved, but is probably good enough for its use (you tell me :-)).
I chose to make it use tl_emalloc and tfree so it is integrated with the rest of the parsing code. I didn't try to understand the logic of tl_emalloc but a better solution would probably use the logic of this allocator without needlessly freeing and allocating on each reallocation (see tl_mem.c).

While debugging this issue, I also noticed an incorrect iteration causing an incorrect read in Valgrind when replacing the custom allocator by free / calloc. The iteration is removing an element, and then tries to access its next element.

I'd be glad to make necessary amendments to this pull request, should it be considered for adoption.

