### PR TITLE
Fix typo qhich (which). Closes #11.

### DIFF
--- a/Man/spin.1
+++ b/Man/spin.1
@@ -93,7 +93,7 @@ to the standard output.
 Translate the LTL formula \f2LTL\f1 into a never claim.
 .br
 This option reads a formula in LTL syntax from the second argument
-and translates it into Promela syntax (a never claim, qhich is Promela's
+and translates it into Promela syntax (a never claim, which is Promela's
 equivalent of a B\(u"chi Automaton).
 The LTL operators are written: [] (always), <> (eventually),
 and U (strong until).  There is no X (next) operator, to secure


### PR DESCRIPTION
This commit fixes a typo in the man page ("qhich" when it should say "which").