### PR TITLE
add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,36 @@
+Spin - Explicit state logic model checking tool
+
+Copyright (C) 2016-2020, Gerard J. Holzmann
+All rights reserved.
+
+Redistribution and use in source  and binary forms, with or without
+modification, are permitted provided  that the following conditions
+are met:
+
+    1. Redistributions  of  source  code   must  retain  the  above
+       copyright notice, this list  of conditions and the following
+       disclaimer.
+
+    2. Redistributions  in binary  form  must  reproduce the  above
+       copyright notice, this list  of conditions and the following
+       disclaimer  in  the  documentation  and/or  other  materials
+       provided with the distribution.
+
+    3. Neither the  name of the  copyright holder nor the  names of
+       its contributors may be used  to endorse or promote products
+       derived from  this software  without specific  prior written
+       permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND  ANY EXPRESS OR IMPLIED WARRANTIES,  INCLUDING, BUT NOT
+LIMITED TO,  THE IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS
+FOR  A  PARTICULAR  PURPOSE  ARE  DISCLAIMED.  IN  NO  EVENT  SHALL
+THE  COPYRIGHT HOLDER  OR CONTRIBUTORS  BE LIABLE  FOR ANY  DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL,  EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA,  OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT  LIABILITY,  OR  TORT (INCLUDING  NEGLIGENCE  OR  OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+


### PR DESCRIPTION
Just making the 3-clause BSD license clear & explicit. Don't quite recall the copyright situation prior to 2016 so didn't go back further. If you can advise on what that should look like I'm happy to get it updated.

May help to further clarify which parts of the repository fall under the 3-Clause BSD license and what may be otherwise licensed. On the Debian side I think we had concerns about copyright ownership wrt iSpin, not sure if we ever got that completely resolved. I'm also curious about the book errata etc. -- is copyright for that stuff potentially in Addison Wesley/Pearson's court?