### PR TITLE
fix `sudo make install` failed on Ubuntu 20.04

### DIFF
--- a/Src/makefile
+++ b/Src/makefile
@@ -27,6 +27,7 @@ YACC?=yacc		# on Solaris: /usr/ccs/bin/yacc
 YFLAGS=-v -d 		# creates y.output and y.tab.h
 DESTDIR?=/usr/local
 INSTALL?=cp		# on linux: install -D
+MKDIR=mkdir
 
 SPIN_OS= spinlex.o sym.o vars.o main.o msc_tcl.o \
 	mesg.o flow.o sched.o run.o pangen1.o pangen2.o \
@@ -41,6 +42,7 @@ spin:	makefile $(SPIN_OS) $(TL_OS) spin.o
 
 install: spin
 	$(INSTALL) spin $(DESTDIR)/bin/spin
+	$(MKDIR) $(DESTDIR)/share/man/man1
 	$(INSTALL) ../Man/spin.1 $(DESTDIR)/share/man/man1/spin.1
 
 spin.o:	makefile spin.y


### PR DESCRIPTION
```
kazuk@kazuk-ubuntu2004:~/Spin$ sudo make install
cd Src; make install
make[1]: ディレクトリ '/home/kazuk/Spin/Src' に入ります
cp		 spin /usr/local/bin/spin
cp		 ../Man/spin.1 /usr/local/share/man/man1/spin.1
cp: 通常ファイル '/usr/local/share/man/man1/spin.1' を作成できません: そのようなファイルやディレクトリはありません
make[1]: *** [makefile:44: install] エラー 1
make[1]: ディレクトリ '/home/kazuk/Spin/Src' から出ます
make: *** [makefile:5: install] エラー 2
```

by default , Ubuntu 20.04 doesn't have `/usr/local/share/man/man1`
then need `mkdir /usr/local/share/man/man1`