### PR TITLE
Fix timestamp warning when model and trail files have equal mtime.

### DIFF
--- a/Src/guided.c
+++ b/Src/guided.c
@@ -49,7 +49,7 @@ newer(char *f1, char *f2)
 
 	if (stat(f1, (struct stat *)&x) < 0) return 0;
 	if (stat(f2, (struct stat *)&y) < 0) return 1;
-	if (x.st_mtime < y.st_mtime) return 0;
+	if (x.st_mtime <= y.st_mtime) return 0;
 	
 	return 1;
 }


### PR DESCRIPTION
I have a program that runs Spin first to generate a trail, and then again to replay it. If this happens fast enough, the modify time of the .pml and .trail files sometimes end up being equal, triggering the warning `spin: warning, <model file> is newer than <trail file>`.

I think it would make more sense to display the warning if the model's mtime is greater than the trail's mtime.
