### PR TITLE
Changed buffer sizes in Src/structs.c

### DIFF
--- a/Src/mesg.c
+++ b/Src/mesg.c
@@ -856,7 +856,7 @@ typedef struct BaseName {
 
 static BaseName *bsn;
 
-void
+static void
 newbasename(char *s)
 {	BaseName *b;
 
@@ -874,7 +874,7 @@ newbasename(char *s)
 	bsn = b;
 }
 
-void
+static void
 delbasename(char *s)
 {	BaseName *b, *prv = (BaseName *) 0;
 
@@ -892,7 +892,7 @@ delbasename(char *s)
 	}	}
 }
 
-void
+static void
 checkindex(char *s, char *t)
 {	BaseName *b;
 
@@ -906,7 +906,7 @@ checkindex(char *s, char *t)
 	}	}
 }
 
-void
+static void
 scan_tree(Lextok *t, char *mn, char *mx)
 {	char sv[512];
 	char tmp[32];
@@ -917,14 +917,17 @@ scan_tree(Lextok *t, char *mn, char *mx)
 	lineno = t->ln;
 
 	if (t->ntyp == NAME)
-	{	if (strlen(t->sym->name) + strlen(mn) > 256) // conservative
+	{	if (strlen(t->sym->name) + strlen(mn) > 512)
 		{	fatal("name too long", t->sym->name);
 		}
 
 		strcat(mn, t->sym->name);
-		strcat(mx, t->sym->name);
+
 		if (t->lft)		/* array index */
-		{	strcat(mn, "[]");
+		{	if(strlen(t->sym->name) + strlen("[]") > 512)
+            {	fatal("name too long", t->sym->name);
+            }
+            strcat(mn, "[]");
 			newbasename(mn);
 				strcpy(sv, mn);		/* save */
 				strcpy(mn, "");		/* clear */
@@ -953,7 +956,7 @@ scan_tree(Lextok *t, char *mn, char *mx)
 	lineno = oln;
 }
 
-void
+static void
 no_nested_array_refs(Lextok *n)	/* a [ a[1] ] with a[1] = 1, causes trouble in pan.b */
 {	char mn[512];
 	char mx[512];

--- a/Src/structs.c
+++ b/Src/structs.c
@@ -412,7 +412,7 @@ struct_name(Lextok *n, Symbol *v, int xinit, char *buf)
 void
 walk2_struct(char *s, Symbol *z)
 {	Lextok *fp, *tl;
-	char eprefix[128];
+	char eprefix[512];
 	int ix;
 
 	memset(eprefix, 0, sizeof(eprefix));
@@ -434,7 +434,7 @@ walk2_struct(char *s, Symbol *z)
 void
 walk_struct(FILE *ofd, int dowhat, char *s, Symbol *z, char *a, char *b, char *c)
 {	Lextok *fp, *tl;
-	char eprefix[128];
+	char eprefix[512];
 	int ix;
 
 	memset(eprefix, 0, sizeof(eprefix));
@@ -456,7 +456,7 @@ walk_struct(FILE *ofd, int dowhat, char *s, Symbol *z, char *a, char *b, char *c
 void
 c_struct(FILE *fd, char *ipref, Symbol *z)
 {	Lextok *fp, *tl;
-	char pref[256], eprefix[300];
+	char pref[512], eprefix[300];
 	int ix;
 
 	ini_struct(z);
@@ -483,7 +483,7 @@ c_struct(FILE *fd, char *ipref, Symbol *z)
 void
 dump_struct(Symbol *z, char *prefix, RunList *r)
 {	Lextok *fp, *tl;
-	char eprefix[256];
+	char eprefix[512];
 	int ix, jx;
 
 	ini_struct(z);


### PR DESCRIPTION
When the promela source has a step which refers to to deeply nested utype element, the spin may produce invalid C code, i.e. the access to the element of C struct is truncated.
This effect is caused by `sprintf` function, which takes a maximum number of bytes of buffer as an argument.
The code uses `sizeof(eprefix)` to determine the size - in C sizeof operator for an array returns a number of bytes allocated for the array.
The sizes of buffers were changed to 512 bytes.