### PR TITLE
Switch argument parsing to argp

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -796,9 +796,7 @@ optimizations(int nr)
 		printf("spin: no implied semi-colons (pre version 6.3)\n");
 		return 0; /* no break */
 	default:
-		printf("spin: bad or missing parameter on -o\n");
-		// usage();
-		break;
+    return -1;
 	}
 	return 1;
 }
@@ -1004,7 +1002,13 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     }
     case 'n': args->T = atoi(arg); tl_terse = 1; break;
     case 'O': old_scope_rules = 1; break;
-    case 'o': args->usedopts += optimizations(atoi(arg)); break;
+    case 'o': {
+      args->usedopts += optimizations(arg[0]);
+      if (args->usedopts == -1) {
+        argp_failure(state, 0, 1, "bad or missing parameter on -o: %c", arg[0]);
+        return EINVAL;
+      }
+      break;
     case 'P': {
       assert(strlen(arg) < sizeof(PreProc));
       strcpy(PreProc, arg);


### PR DESCRIPTION
This PR converts Spin's manual parsing logic into using the GNU libc extension [argp](https://www.gnu.org/software/libc/manual/html_node/Argp.html)

### Pros

This is a large change, and a large diff, but I think this change is beneficial for several reasons:
1. This removes the maintainence burden of parsing in error-prone cases ([manually incrementing argv and argc](https://github.com/nimble-code/Spin/blob/master/Src/main.c#L915), [pointer arithmetic to parse parts of arguments](https://github.com/nimble-code/Spin/blob/master/Src/main.c#L925)
2. Automatic generation of documentation (replaces having to update the [usage](https://github.com/nimble-code/Spin/blob/master/Src/main.c#L616-L708) function manually)
3. Simpler application logic in some places
4. Easier testing of the application due to the separation of parsing logic
5. Reduction of complex control-flow such as `goto`

### Cons

However, this does come with several downsides that I can think of:
1. Increased application dependencies
2. Reduced backwards-compatibility, another option, `getopt`, may  be better in this regard
3. Lack of ability to format documentation manually

### Rationale

I think that these pros still outweigh the cons, however, because of the simplification of application logic, and reduced maintenance burden. Originally, I planned to go with the POSIX `getopt` instead, but it lacked the features for automatic documentation generation, and had more complex parsing logic. I can also revisit this if necessary, if any features are not available in argp.

### Safety and compatibility with the existing library

Great care was taken to make sure that this change does not conflict with the existing logic, and can serve as a drop-in replacement. Some of the safety steps taken were:

1. Enable argp's use of the `ARGP_LONG_ONLY` flag, which accepts flags containing a single dash (e.g. "-run"), instead of the argp default of just "--run". This is what Spin uses by default, so the parsing of these options should not be accepted
2. Lines such as [this](https://github.com/nimble-code/Spin/blob/master/Src/main.c#L908-L909) are a bit more complex.
  1. `&argv[1][0]` refers to the name of the entire argument, e.g. "-Dfoo". However, in argp, the command-line option and argument are parsed separately, requiring a new heap-allocated string to concatenate the option name to the argument. This is safe, and would not likely hurt performance, because parsing only occurs once, and not at runtime, but is something worth considering
  2. `PreArg` was changed to a helper function that checks an additional assert, and all the call sites were updated to use this variable correctly.
3. Parsing the options to run was done by setting an internal state flag, which only affects parsing

I hope this can be a welcome inclusion into Spin, or a starting point to another discussion, because I have far more ideas after working on this

~Nick